### PR TITLE
Use the same default collation as the old PG data directory

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -276,6 +276,12 @@ docker_temp_server_stop() {
 	pg_ctl -D "$PGDATA" -m fast -w stop
 }
 
+# Initialise PG data directory in a temp location with a specific locale
+initdb_locale() {
+	echo "Initialising PostgreSQL 15 data directory"
+	/usr/local/bin/initdb --locale=${1} /var/lib/postgresql/data/new/
+}
+
 # check arguments for an option that would cause postgres to stop
 # return true if there is one
 _pg_want_help() {
@@ -363,31 +369,48 @@ _main() {
 		chmod 0700 /var/lib/postgresql/data/old /var/lib/postgresql/data/new
 		mv -v /var/lib/postgresql/tempdir/* /var/lib/postgresql/data/old/
 
-		# Initialise a new PG 15 data directory in a temporary location
-		echo "Initialising PostgreSQL 15 data directory"
-		/usr/local/bin/initdb /var/lib/postgresql/data/new/
-
 		# Perform the data directory upgrade
 		if [ "$PGVER" = "9.5" ]; then
 			echo "PostgreSQL 9.5 database files found, upgrading to PostgreSQL 15"
+			# Initialise the new data directory using the same collation as the old one
+			COLL=$(echo 'SHOW LC_COLLATE' | /usr/local-pg9.5/bin/postgres --single -D /var/lib/postgresql/data/old | grep 'lc_collate = "' | cut -d '"' -f 2)
+			initdb_locale ${COLL}
 			/usr/local/bin/pg_upgrade --link -d /var/lib/postgresql/data/old -D /var/lib/postgresql/data/new -b /usr/local-pg9.5/bin -B /usr/local/bin
 		elif [ "$PGVER" = "9.6" ]; then
 			echo "PostgreSQL 9.6 database files found, upgrading to PostgreSQL 15"
+			# Initialise the new data directory using the same collation as the old one
+			COLL=$(echo 'SHOW LC_COLLATE' | /usr/local-pg9.6/bin/postgres --single -D /var/lib/postgresql/data/old | grep 'lc_collate = "' | cut -d '"' -f 2)
+			initdb_locale ${COLL}
 			/usr/local/bin/pg_upgrade --link -d /var/lib/postgresql/data/old -D /var/lib/postgresql/data/new -b /usr/local-pg9.6/bin -B /usr/local/bin
 		elif [ "$PGVER" = "10" ]; then
 			echo "PostgreSQL 10 database files found, upgrading to PostgreSQL 15"
+			# Initialise the new data directory using the same collation as the old one
+			COLL=$(echo 'SHOW LC_COLLATE' | /usr/local-pg10/bin/postgres --single -D /var/lib/postgresql/data/old | grep 'lc_collate = "' | cut -d '"' -f 2)
+			initdb_locale ${COLL}
 			/usr/local/bin/pg_upgrade --link -d /var/lib/postgresql/data/old -D /var/lib/postgresql/data/new -b /usr/local-pg10/bin -B /usr/local/bin
 		elif [ "$PGVER" = "11" ]; then
 			echo "PostgreSQL 11 database files found, upgrading to PostgreSQL 15"
+			# Initialise the new data directory using the same collation as the old one
+			COLL=$(echo 'SHOW LC_COLLATE' | /usr/local-pg11/bin/postgres --single -D /var/lib/postgresql/data/old | grep 'lc_collate = "' | cut -d '"' -f 2)
+			initdb_locale ${COLL}
 			/usr/local/bin/pg_upgrade --link -d /var/lib/postgresql/data/old -D /var/lib/postgresql/data/new -b /usr/local-pg11/bin -B /usr/local/bin
 		elif [ "$PGVER" = "12" ]; then
 			echo "PostgreSQL 12 database files found, upgrading to PostgreSQL 15"
+			# Initialise the new data directory using the same collation as the old one
+			COLL=$(echo 'SHOW LC_COLLATE' | /usr/local-pg12/bin/postgres --single -D /var/lib/postgresql/data/old | grep 'lc_collate = "' | cut -d '"' -f 2)
+			initdb_locale ${COLL}
 			/usr/local/bin/pg_upgrade --link -d /var/lib/postgresql/data/old -D /var/lib/postgresql/data/new -b /usr/local-pg12/bin -B /usr/local/bin
 		elif [ "$PGVER" = "13" ]; then
 			echo "PostgreSQL 13 database files found, upgrading to PostgreSQL 15"
+			# Initialise the new data directory using the same collation as the old one
+			COLL=$(echo 'SHOW LC_COLLATE' | /usr/local-pg13/bin/postgres --single -D /var/lib/postgresql/data/old | grep 'lc_collate = "' | cut -d '"' -f 2)
+			initdb_locale ${COLL}
 			/usr/local/bin/pg_upgrade --link -d /var/lib/postgresql/data/old -D /var/lib/postgresql/data/new -b /usr/local-pg13/bin -B /usr/local/bin
 		elif [ "$PGVER" = "14" ]; then
 			echo "PostgreSQL 14 database files found, upgrading to PostgreSQL 15"
+			# Initialise the new data directory using the same collation as the old one
+			COLL=$(echo 'SHOW LC_COLLATE' | /usr/local-pg14/bin/postgres --single -D /var/lib/postgresql/data/old | grep 'lc_collate = "' | cut -d '"' -f 2)
+			initdb_locale ${COLL}
 			/usr/local/bin/pg_upgrade --link -d /var/lib/postgresql/data/old -D /var/lib/postgresql/data/new -b /usr/local-pg14/bin -B /usr/local/bin
 		else
 			echo "Unknown version of PostgreSQL database files found, aborting completely"


### PR DESCRIPTION
When initialising the new PostgreSQL 15 data directory, use the same default collation as the existing data directory we're upgrading.